### PR TITLE
feat/CustomStateSet

### DIFF
--- a/reports/2022.html
+++ b/reports/2022.html
@@ -1262,51 +1262,101 @@ class FancyInput extends HTMLElement {
           <dt>Previous WCCG Report(s)</dt>
           <dd>N/A</dd>
           <dt>GitHub issues:</dt>
-          <dd>---</dd>
+          <dd>https://github.com/WICG/webcomponents/issues/738</dd>
           <dt>Browser positions:</dt>
-          <dd>---</dd>
+          <dd>
+            <ul>
+              <li>
+                <strong>Chrome</strong> &mdash; shipped
+              </li>
+              <li>
+                <strong>Firefox</strong> &mdash;
+              </li>
+              <li>
+                <strong>Webkit</strong> &mdash; <a href="https://github.com/WebKit/standards-positions/issues/56">WebKit position</a>
+              </li>
+            </ul>
+          </dd>
         </dl>
       </section>
       <section>
         <h3>Description</h3>
-        <p>---</p>
+        
+        <blockquote cite="https://wicg.github.io/custom-state-pseudo-class/#motivation">
+          <p>Build-in elements provided by user agents have certain “states” that can change over time depending on user interaction and other factors, and are exposed to web authors through pseudo classes. For example, some form controls have the “invalid” state, which is exposed through the :invalid pseudo-class.</p>
+  
+          <p>Like built-in elements, custom elements can have various states to be in too, and custom element authors want to expose these states in a similar fashion as the built-in elements.</p>
+        </blockquote>
       </section>
       <section>
         <h3>Status</h3>
         <ul>
-          <li>---</li>
+          <li>A <a href="https://wicg.github.io/custom-state-pseudo-class/#exposing">draft of the spec has been written in WICG</a>.</li>
         </ul>
       </section>
       <section>
         <h3>Initial API Summary/Quick API Proposal</h3>
-        <p>Summary or proposal based on current status; paragraph(s) and code.</p>
+        <p>The <code>CustomStateSet</code> API allows component authors to expose internal component state for use in styling or other element-matching operations (such as <code>querySelector</code></p>
+
+        <p>This is different from a custom element sprouting a class (via <code>this.classList.add</code> in any state added to the custom element can be seen as internal (similar to the <code>:checked</code> pseud-selector for input elements).</code></p>
+
+        <p>To allow for this operation, a set-like API is exposed at <code>ElementInternals.prototype.states</code>, meaning that only custom elements can apply custom states. An example might look like the following:</p>
+
+        <pre>
+          <code>
+class FancyElement extends HTMLElement {
+  #internals = this.attachInternals();
+
+  constructor() {
+    super();
+    
+    const root = this.attachShadow({ mode: 'open' });
+    const button = document.createElement('button');
+    button.innerText = 'Add clicked state';
+    button.setAttribute('part', 'btn');
+    root.append(button);
+
+    this.addEventListener('click', function wasClicked() {
+      this.#internals.states.add('--clicked');
+      this.removeEventListener('click', wasClicked);
+    });
+  }
+}
+customElements.define('fancy-element', FancyElement);
+          </code>
+        </pre>
+
+        <p>Consumers of the <code>fancy-element</code> code can now take advantage of the <code>:--clicked</code> state in CSS or in any DOM querying API to modify or select the relevant element once clicked.</p>
+
+        <p>For example, to change the background of the element's <code>btn</code> part, a consuming developer could apply the following CSS:</p>
+
+        <pre>
+          <code>
+:--clicked::part(btn) {
+  background: rebeccapurple;
+}
+          </code>
+        </pre>
+        
+        <p>Alternatively, a consuming developer could call <code>document.querySelectorAll(':--clicked')</code> to target all elements with the custom state.</p>
       </section>
       <section>
         <h3>Key Scenarios</h3>
-        <p>---</p>
+        <ul>
+          <li>Allow custom element authors to expose internal state for use in CSS</li>
+          <li>Allow custom element authros to expose internal state for use in DOM selection operations</li>
+        </ul>
       </section>
       <section>
         <h3>Concerns</h3>
         <ul>
-          <li>---</li>
-        </ul>
-      </section>
-      <section>
-        <h3>Dissenting Opinion</h3>
-        <ul>
-          <li>---</li>
+          <li>Most of the concerns around this topic are related to syntax rather than functionality. For example, some prefer the selector to match state to be something along the lines of <code>:state(--state)</code>; however, it appears as if the current status is fairly accepted right now.</li>
         </ul>
       </section>
       <section>
         <h3>Related Specs</h3>
         <ul>
-          <li>---</li>
-        </ul>
-      </section>
-      <section>
-        <h3>Open Questions</h3>
-        <ul>
-          <li>---</li>
+          <li><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-face-example">Form-associated custom elements</a></li>
         </ul>
       </section>
     </section>

--- a/reports/2022.html
+++ b/reports/2022.html
@@ -24,6 +24,10 @@
             url: "https://github.com/alangdm",
           },
           {
+            name: "Rob Eisenberg",
+            url: "https://github.com/eisenbergeffect",
+          },
+          {
             name: "Owen Buckley",
             url: "https://github.com/thescientist13",
           },
@@ -167,15 +171,15 @@
             </tr>
             <tr>
               <th><a href="#lazy-custom-element-definitions">Lazy custom element definitions</a></th>
+              <td><a href="https://github.com/WICG/webcomponents/issues/782">WICG/webcomponents#782</a></td>
               <td></td>
-              <td></td>
-              <td></td>
+              <td>Uncertain</td>
             </tr>
             <tr>
               <th><a href="#dom-parts">DOM Parts</a></th>
+              <td><a href="https://github.com/WICG/webcomponents/blob/gh-pages/proposals/DOM-Parts.md">DOM Part API - First Step of Template Instantiation</a></td>
               <td></td>
-              <td></td>
-              <td></td>
+              <td>Uncertain</td>
             </tr>
             <tr>
               <th><a href="#html-modules">HTML modules</a></th>
@@ -185,9 +189,9 @@
             </tr>
             <tr>
               <th><a href="#custom-attributes">Custom Attributes</a></th>
+              <td><a href="https://github.com/w3c/webcomponents-cg/discussions/31#discussioncomment-3163644">Web Components CG Discussion</a></td>
               <td></td>
-              <td></td>
-              <td></td>
+              <td>Not addressed</td>
             </tr>
             <tr>
               <th>---</th>
@@ -924,51 +928,117 @@ class FancyInput extends HTMLElement {
           <dt>Previous WCCG Report(s)</dt>
           <dd><a href="https://w3c.github.io/webcomponents-cg/index.html#declarative-custom-elements">2021</a></dd>
           <dt>GitHub issues:</dt>
-          <dd>---</dd>
+          <dd>
+            <ul>
+              <li><a href="https://github.com/WICG/webcomponents/blob/gh-pages/proposals/Declarative-Custom-Elements-Strawman.md">Initial Proposal</a></li>
+              <li><a href="https://github.com/Westbrook/custom-element-proposals/pull/1">Single File Component Explainer</a></li>
+              <li><a href="https://github.com/WICG/webcomponents/issues/645">Cross-over with HTML Modules</a></li>
+              <li><a href="https://github.com/w3c/webcomponents-cg/issues/32">Discussion</a></li>
+            </ul>
+          </dd>
           <dt>Browser positions:</dt>
           <dd>---</dd>
         </dl>
       </section>
       <section>
         <h3>Description</h3>
-        <p>---</p>
+        <p>A method of creating custom elements completely with declarative HTML, not requiring JavaScript.</p>
       </section>
       <section>
         <h3>Status</h3>
         <ul>
-          <li>---</li>
+          <li>Strawperson proposal available.</li>
+          <li>Dependent on many other proposals that are not yet finished.</li>
+          <li>Many people would like to have something like this but it seems too early due to the number of unfinished dependencies.</li>
         </ul>
       </section>
       <section>
         <h3>Initial API Summary/Quick API Proposal</h3>
-        <p>Summary or proposal based on current status; paragraph(s) and code.</p>
+        <p>The following, copied from the original strapwerson proposal, demonstrates how a declarative custom element could be defined with the need for JavaScript.</p>
+        <pre class="html">&lt;definition&nbsp;name=&quot;percentage&#45;bar&quot;&gt;
+&nbsp;&nbsp;&nbsp;&nbsp;&lt;template&nbsp;shadowmode=&quot;closed&quot;&gt;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;div&nbsp;id=&quot;progressbar&quot;&nbsp;role=&quot;progressbar&quot;&nbsp;aria&#45;valuemin=&quot;0&quot;&nbsp;aria&#45;valuemax=&quot;100&quot;&nbsp;aria&#45;valuenow=&quot;{{\root.attributes.percentage.value}}&quot;&gt;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;div&nbsp;id=&quot;bar&quot;&nbsp;style=&quot;width:&nbsp;{{\root.attributes.percentage.value}}%&quot;&gt;&lt;/div&gt;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;div&nbsp;id=&quot;label&quot;&gt;&lt;slot&gt;&lt;/slot&gt;&lt;/div&gt;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;/div&gt;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;style&gt;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;:host&nbsp;{&nbsp;display:&nbsp;inline&#45;block&nbsp;!important;&nbsp;}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#progressbar&nbsp;{&nbsp;position:&nbsp;relative;&nbsp;display:&nbsp;block;&nbsp;width:&nbsp;100%;&nbsp;height:&nbsp;100%;&nbsp;}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#bar&nbsp;{&nbsp;background&#45;color:&nbsp;#36f;&nbsp;height:&nbsp;100%;&nbsp;}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;#label&nbsp;{&nbsp;position:&nbsp;absolute;&nbsp;top:&nbsp;0px;&nbsp;left:&nbsp;0px;&nbsp;width:&nbsp;100%;&nbsp;height:&nbsp;100%;&nbsp;text&#45;align:&nbsp;center;&nbsp;}
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;/style&gt;
+&nbsp;&nbsp;&nbsp;&nbsp;&lt;/template&gt;
+&lt;/definition&gt;
+        </pre>
       </section>
       <section>
         <h3>Key Scenarios</h3>
-        <p>---</p>
+        <ul>
+          <li>Create reusable custom elements without needing to load or run JavaScript.</li>
+          <li>Use custom elements in noscript contexts.</li>
+          <li>Open up new opportunities for more efficient server-side-rendering. e.g. Smaller html payloads due to less duplication of HTML</li>
+          <li>Codify framework "single file component" patterns in the platform.</li>
+        </ul>
       </section>
       <section>
         <h3>Concerns</h3>
         <ul>
-          <li>---</li>
+          <li>Binding syntax for attributes is extremely verbose. e.g. "{{\root.attributes.percentage.value}}" is used instead of something terser like "{{\percentage}}" .</li>
+          <li>Binding syntax doesn't look extensible.</li>
+          <li>A lot of cooperation from tooling and plugin authors will be required to enable developer ergonomics and adoption.</li>
+          <li>The current proposal's script model creates a second way of coding components with some different behavior from what we have today.</li>
+          <li>The current proposal conflicts in syntax with Declarative Shadow DOM.</li>
         </ul>
       </section>
       <section>
         <h3>Dissenting Opinion</h3>
-        <ul>
-          <li>---</li>
-        </ul>
+        <p>No dissenting opinions yet.</p>
       </section>
       <section>
         <h3>Related Specs</h3>
         <ul>
-          <li>---</li>
+          <li>
+            <a href="https://html.spec.whatwg.org/multipage/scripting.html#htmltemplateelement">HTML Template Element</a>
+          </li>
+          <li>
+            <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#form-associated-custom-elements">Form Associated Custom Elements</a>
+          </li>
+          <li>
+            <a href="https://wicg.github.io/custom-state-pseudo-class/#customstateset">Custom State Set</a>
+          </li>
+          <li>
+            <a href="#declarative-css-modules">Declarative CSS Modules</a>
+          </li>
+          <li>
+            <a href="#dom-parts">DOM Part API</a>
+          </li>
+          <li>
+            <a href="https://github.com/WICG/webcomponents/blob/gh-pages/proposals/Template-Instantiation.md">Template Instantiation</a>
+          </li>
+          <li>
+            <a href="#scoped-element-registries">Scoped Custom Element Registries</a>
+          </li>
+          <li>
+            <a href="#lazy-custom-element-definitions">Lazy Custom Element Definitions</a>
+          </li>
+          <li>
+            <a href="#cross-root-aria">Cross Root Aria</a>
+          </li>
+          <li>
+            <a href="#html-modules">HTML Modules</a>
+          </li>
         </ul>
       </section>
       <section>
         <h3>Open Questions</h3>
         <ul>
-          <li>---</li>
+          <li>Shouldn't attributes be declared instead of inferred through the bindings?</li>
+          <li>How to handle boolean attributes and reflected attributes?</li>
+          <li>If script is provided through src, how should loading be handled? Does it block or can it be partially upgraded?</li>
+          <li>How does this support aria roles, degegated aria, and cross-root aria?</li>
+          <li>How is form association handled?</li>
+          <li>When script is provided, how does it interact with or gain access to the template and styles?</li>
+          <li>Should there be ways to ship definitions along with a data set or top-level template so that small payloads of data can be automatically combined with template and element declarations without the need for JS?</li>
         </ul>
       </section>
     </section>
@@ -1260,51 +1330,155 @@ class FancyInput extends HTMLElement {
           <dt>Previous WCCG Report(s)</dt>
           <dd>N/A</dd>
           <dt>GitHub issues:</dt>
-          <dd>---</dd>
+          <dd>
+            <ul>
+              <li>
+                <a href="https://github.com/WICG/webcomponents/issues/782">Initial Proposal</a>
+              </li>
+              <li>
+                <a href="https://github.com/WICG/webcomponents/issues/444">Alternative Proposal (closed)</a>
+              </li>
+              <li>
+                <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1460815">Firefox Internal Issue</a>
+              </li>
+            </ul>
+          </dd>
           <dt>Browser positions:</dt>
           <dd>---</dd>
         </dl>
       </section>
       <section>
         <h3>Description</h3>
-        <p>---</p>
+        <p>
+          Enable the browser to automatically load a custom element definition when it first sees the associated tag.
+        </p>
       </section>
       <section>
         <h3>Status</h3>
         <ul>
-          <li>---</li>
+          <li>
+            Strawperson proposal available.
+          </li>
+          <li>
+            There is further disagreement as to whether this feature is needed. However, the community generally tends to lean toward wanting some version of this.
+          </li>
+          <li>
+            There are many open questions around the feature-set as well as how it interoperates with other proposals.
+          </li>
         </ul>
       </section>
       <section>
         <h3>Initial API Summary/Quick API Proposal</h3>
-        <p>Summary or proposal based on current status; paragraph(s) and code.</p>
+        <p>Below is a definition for the proposed new CustomElementRegistry API.</p>
+        <pre class="javascript">
+          CustomElementRegistry#defineLazy(tagName: string, loader: () => Promise<CustomElementDefinition>);
+        </pre>
       </section>
       <section>
         <h3>Key Scenarios</h3>
-        <p>---</p>
+        <p>
+          <ul>
+            <li>
+              Enable bundlers to split code based on the presence of dynamic import calls. Tools like guess.js can integrate with bundlers to provide statistical analysis of actual usage, optimizing bundles better. This proposal would enable that type of integration.
+            </li>
+            <li>
+              Enable consumers of web components to not have to worry about handling the loading of the code in every place where a component is used. This is important in systems where the content may leverage a potential large number of Web Components but where only a few are actually needed in any given experience. E.g. News sites, feeds, etc.
+            </li>
+            <li>
+              Firefox has an internal API for lazy loading definitions.
+            </li>
+          </ul>
+        </p>
       </section>
       <section>
         <h3>Concerns</h3>
         <ul>
-          <li>---</li>
+          <li>
+            This feature could make it easy to create a "loading pyramid". e.g. Component A loads, which causes B and C to load, which then cause D and E to load, etc.
+          </li>
         </ul>
       </section>
       <section>
         <h3>Dissenting Opinion</h3>
         <ul>
-          <li>---</li>
+          <li>
+            Breaks Principle of Least Surprise. If you see a component in the HTML, you expect to be able to interact with it. But this may fail due to the component not being loaded yet.
+          </li>
+          <li>
+            Seems backward to have the browser tell the experience when to load code, rather than the experience telling the browser.
+          </li>
+          <li>
+            Rather than focusing on this high level feature, we should instead add low-level APIs that enable building this feature with a few lines of code. Recognizes that MutationObserver is not sufficient, but isn't convinced about lazy definitions.
+          </li>
         </ul>
       </section>
       <section>
         <h3>Related Specs</h3>
         <ul>
-          <li>---</li>
+          <li>
+            <a href="#scoped-element-registries">Scoped Custom Element Registries</a>
+          </li>
+          <li>
+            <a href="#declarative-shadow-dom">Declarative Shadow DOM</a>
+          </li>
+          <li>
+            <a href="#children-changed-callback">Children Changed Callback</a> 
+          </li>
+          <li>
+            <a href="https://github.com/whatwg/dom/issues/533">Observable Node Connectedness</a>
+          </li>
+          <li>
+            <a href="https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/pending-task.md">Pending Task Protocol</a>
+          </li>
         </ul>
       </section>
       <section>
         <h3>Open Questions</h3>
         <ul>
-          <li>---</li>
+          <li>
+            How do we handle ElementDefinitionOptions? CustomElementDefinition isn't defined in the proposal above. Does it include this? How?
+          </li>
+          <li>
+            Should there be a parallel API to unload a definition?
+          </li>
+          <li>
+            Should there be additional configuration options for load triggers?
+            <ul>
+              <li>
+                When certain attributes change.
+              </li>
+              <li>
+                When certain events are fired.
+              </li>
+              <li>
+                When scrolled into view.
+              </li>
+              <li>
+                When the mouse is close.
+              </li>
+            </ul>
+          </li>
+          <li>
+            How does this work with sync calls to document.createElement?
+          </li>
+          <li>
+            Should there be wild card registrations that can be used to load collections of components based on a pattern?
+          </li>
+          <li>
+            Could all of this be handled by a more general-purpose callback that was simply fired when an unknown element name is seen?
+          </li>
+          <li>
+            How do we handle lazy definitions when someone calls "get" on the CustomElementsRegistry?
+          </li>
+          <li>
+            If a component is lazy defined but has not yet loaded, what happens when someone tries to synchronously define an element with the same name?
+          </li>
+          <li>
+            How does a component know when all its lazily loaded children are done loading?
+          </li>
+          <li>
+            Should there be a more declarative API for this to tell the parser where to fine unknown elements?
+          </li>
         </ul>
       </section>
     </section>
@@ -1316,51 +1490,148 @@ class FancyInput extends HTMLElement {
           <dt>Previous WCCG Report(s)</dt>
           <dd>N/A</dd>
           <dt>GitHub issues:</dt>
-          <dd>---</dd>
+          <dd>
+            <ul>
+              <li>
+                <a href="https://github.com/WICG/webcomponents/blob/gh-pages/proposals/DOM-Parts.md">Initial Proposal</a>
+              </li>
+              <li>
+                <a href="https://docs.google.com/document/d/1UVtF1gM6XY-_NKm2_c045K803U3ZTjfyluLeToJlIUk/edit">Alternative Diffing Proposal</a>
+              </li>
+              <li>
+                <a href="https://github.com/WICG/webcomponents/issues/902">Naming Discussion</a>
+              </li>
+            </ul>
+          </dd>
           <dt>Browser positions:</dt>
           <dd>---</dd>
         </dl>
       </section>
       <section>
         <h3>Description</h3>
-        <p>---</p>
+        <p>A mechanism to insert or replace content at specific locations within the DOM tree.</p>
       </section>
       <section>
         <h3>Status</h3>
         <ul>
-          <li>---</li>
+          <li>Strawperson proposal available.</li>
+          <li>General consensus is that this is needed and could be used by existing Web Component and Frontend libraries and frameworks.</li>
+          <li>Lots of bike shedding over naming.</li>
+          <li>There is a large number of open questions both on this feature and how it interacts with other proposals.</li>
         </ul>
       </section>
       <section>
         <h3>Initial API Summary/Quick API Proposal</h3>
-        <p>Summary or proposal based on current status; paragraph(s) and code.</p>
+        <p>The following is a summary of the core types from the proposal.</p>
+        <pre class="javascript">
+          interface Part {
+              attribute any value;
+              void commit();
+          };
+          
+          
+          interface NodePart : Part {
+              readonly attribute Node node;
+          };
+          
+          
+          interface AttributePart : Part {
+              constructor(Element element, DOMString qualifiedName, DOMString? namespace);
+              readonly attribute DOMString prefix;
+              readonly attribute DOMString localName;
+              readonly attribute DOMString namespaceURI;
+          };
+          
+          
+          interface ChildNodePart : Part {
+              constructor(Node node, Node? previousSibling, Node? nextSibling);
+              readonly attribute Node parentNode;
+              readonly attribute Node? previousSibling;
+              readonly attribute Node? nextSibling;
+          }
+          </pre>
       </section>
       <section>
         <h3>Key Scenarios</h3>
-        <p>---</p>
+        <p>
+          <ul>
+            <li>
+              Enable batched updates to the DOM, usable by library/framework view engines. Library authors would be able to remove part of their user-land solution, shrinking libraries and reducing JS execution.
+            </li>
+            <li>
+              Needed as a steppingstone towards reactive bindings for custom elements.
+            </li>
+          </ul>
+        </p>
       </section>
       <section>
         <h3>Concerns</h3>
         <ul>
-          <li>---</li>
+          <li>
+            Naming the API as "Part" could cause confusion with CSS Shadow Parts. No consensus over naming reached yet.
+          </li>
         </ul>
       </section>
       <section>
         <h3>Dissenting Opinion</h3>
         <ul>
-          <li>---</li>
+          <li>
+            Some individuals, particularly from React-ish backgrounds, would prefer a diffing-based alternative to batched updates. However, there are several problems with the diffing proposal.
+            <ul>
+              <li>
+                The core proposal shows diffing between real DOM nodes, which is very heavy.
+              </li>
+              <li>
+                The diffing proposal acknowledges the above flaw and attempts to solve it by proposing a JavaScript API to create virtual DOMs but it's unclear why existing libraries can't be used for this.
+              </li>
+              <li>
+                It is not clear how this maps to fully declarative templates down the road, which are created in real DOM.
+              </li>
+            </ul>
+          </li>
         </ul>
       </section>
       <section>
         <h3>Related Specs</h3>
         <ul>
-          <li>---</li>
+          <li>
+            <a href="#declarative-shadow-dom">Declarative Shadow DOM</a>
+          </li>
+          <li>
+            <a href="#declarative-custom-elements">Declarative Custom Elements</a>
+          </li>
+          <li>
+            <a href="https://github.com/WICG/webcomponents/blob/gh-pages/proposals/Template-Instantiation.md">Template Instantiation</a>
+          </li>
+          <li>
+            <a href="#custom-attributes">Custom Attributes</a>
+          </li>
         </ul>
       </section>
       <section>
         <h3>Open Questions</h3>
         <ul>
-          <li>---</li>
+          <li>
+            How to handle attribute parts when there is a mixture of static and dynamic parts needed to assemble the attribute value?
+          </li>
+          <li>
+            How to handle child node updates when there is a mixture of elements, text, etc. that are potentially changing.
+          </li>
+          <li>
+            How to handle setting properties?
+          </li>
+          <li>
+            How do libraries and frameworks handle custom behaviors/directives?
+          </li>
+          <li>
+            How do we handle batches of updates and ordering of updates?
+          </li>
+          <li>
+            How do we clone templates to efficiently reproduce the template content and the proper part setup?
+          </li>
+          <li>
+            Could part references be shared with workers to allow DOM updates from workers?
+          </li>
         </ul>
       </section>
     </section>
@@ -1428,51 +1699,126 @@ class FancyInput extends HTMLElement {
           <dt>Previous WCCG Report(s)</dt>
           <dd>N/A</dd>
           <dt>GitHub issues:</dt>
-          <dd>---</dd>
+          <dd>
+            <ul>
+              <li>
+                <a href="https://github.com/w3c/webcomponents-cg/discussions/31#discussioncomment-3163644">Discussion</a>
+              </li>
+              <li>
+                <a href="https://github.com/whatwg/html/issues/2271">Custom Attribute Name Rules</a>
+              </li>
+              <li>
+                <a href="https://github.com/whatwg/dom/issues/533#issuecomment-405530738">Node Connectedness comment about Custom Attributes</a>
+              </li>
+            </ul>
+          </dd>
           <dt>Browser positions:</dt>
           <dd>---</dd>
         </dl>
       </section>
       <section>
         <h3>Description</h3>
-        <p>---</p>
+        <p>Enable developers to create reusable custom behaviors that that can be declaratively applied to any element.</p>
       </section>
       <section>
         <h3>Status</h3>
         <ul>
-          <li>---</li>
+          <li>
+            No official proposal yet.
+          </li>
+          <li>
+            While there is no official issue for this yet, this feature request crops up in several discussions on other threads. In general, the community seems to be very interested in having something like this.
+          </li>
         </ul>
       </section>
       <section>
         <h3>Initial API Summary/Quick API Proposal</h3>
-        <p>Summary or proposal based on current status; paragraph(s) and code.</p>
+        <p>There is no issue or proposal yet. The following can serve as an initial idea, inspired by custom elements.</p>
+        <pre class="javascript">
+          class MaterialRipple extends Attr {
+            // ownerElement inherited from Attr
+            // name inherited from Attr
+            // value inherited from Attr
+            // ...
+        
+            connectedCallback () {
+              // called when the ownerElement is connected to the DOM
+            }
+        
+            disconnectedCallback () {
+              // called when the ownerElement is disconnected from the DOM
+            }
+        
+            attributeChangedCallback() {
+              // called when the value property of this attribute changes
+            }
+        }
+        
+        customAttributes.define("material-ripple", MaterialRipple);
+        </pre>
       </section>
       <section>
         <h3>Key Scenarios</h3>
-        <p>---</p>
+        <p>
+          <ul>
+            <li>Enable more built-in patterns to be accomplishable by developer extensions. e.g. label for, img src</li>
+            <li>Enable behaviors to be written once and used on any element.</li>
+            <li>May serve as a better solution than the "is" capability of custom elements (which isn't fully supported).</li>
+          </ul>
+        </p>
       </section>
       <section>
         <h3>Concerns</h3>
-        <ul>
-          <li>---</li>
-        </ul>
+        <p>No concerns yet.</p>
       </section>
       <section>
         <h3>Dissenting Opinion</h3>
-        <ul>
-          <li>---</li>
-        </ul>
+        <p>No dissenting opinions yet.</p>
       </section>
       <section>
         <h3>Related Specs</h3>
         <ul>
-          <li>---</li>
+          <li>
+            <a href="#declarative-shadow-dom">Declarative Shadow DOM</a>
+          </li>
+          <li>
+            <a href="#lazy-custom-element-definitions">Lazy Custom Element Definitions</a>
+          </li>
+          <li>
+            <a href="#dom-parts">DOM Part API</a>
+          </li>
+          <li>
+            <a href="#scoped-element-registries">Scoped Custom Element Registries</a>
+          </li>
+          <li>
+            <a href="https://github.com/WICG/webcomponents/blob/gh-pages/proposals/Template-Instantiation.md">Template Instantiation</a>
+          </li>
         </ul>
       </section>
       <section>
         <h3>Open Questions</h3>
         <ul>
-          <li>---</li>
+          <li>
+            How should custom attributes be named? Can they follow the same hyphen convention as custom elements?
+          </li>
+          <li>
+            SVG has some CSS properties that it surfaces as attributes. How do we prevent conflicts?
+          </li>
+          <li>
+            It could be beneficial for a custom attribute to have access to the shadow DOM of a custom element, but is this a security issue?
+          </li>
+          <li>
+            Should we allow access to ElementInternals? Is that a security problem? Is there a limited version of this we could support? Do custom elements need to allow this? What about built-ins?
+          </li>
+          <li>
+            How to handle when "removeAttribute" is called?
+          </li>
+          <li>
+            Should there be special handling for boolean attributes?
+          </li>
+          <li>
+            Should there be a specific set of pre-defined attributes that can be opted into for custom elements. e.g. for, src
+          </li>
         </ul>
       </section>
     </section>

--- a/reports/2022.html
+++ b/reports/2022.html
@@ -426,45 +426,66 @@ class FancyInput extends HTMLElement {
           <dt>Previous WCCG Report(s)</dt>
           <dd><a href="https://w3c.github.io/webcomponents-cg/index.html#constructable-stylesheets-adoptedstylesheets">2021</a></dd>
           <dt>GitHub issues:</dt>
-          <dd>---</dd>
+          <dd><a href="https://github.com/WICG/webcomponents/issues/468">WICG/webcomponents#468</a></dd>
           <dt>Browser positions:</dt>
-          <dd>---</dd>
+          <dd><a href="https://chromestatus.com/feature/5394843094220800" target="_blank">Chrome (Shipped)</a></dd>
+          <dd><a href="https://github.com/mozilla/standards-positions/issues/103" target="_blank">Mozilla (Shipped)</a></dd>
+          <dd><a href="https://github.com/WebKit/standards-positions/issues/42" target="_blank">Safari</a></dd>
         </dl>
       </section>
       <section>
         <h3>Description</h3>
-        <p>---</p>
+        <p><a href="https://wicg.github.io/construct-stylesheets/" target="_blank">Constructable Stylesheets</a> and adoptedStyleSheets enable adding styles directly to shadow roots without creating new DOM elements. Because a single stylesheet object can be adopted by multiple scopes, it also allows sharing of styles that can be centrally modified.</p>
       </section>
       <section>
         <h3>Status</h3>
         <ul>
-          <li>---</li>
+          <li>Partial consensus; shipped in both <a href="https://web.dev/constructable-stylesheets/" target="_blank">Chrome</a> and <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1520690" target="_blank">Firefox</a></li>
         </ul>
       </section>
       <section>
         <h3>Initial API Summary/Quick API Proposal</h3>
-        <p>Summary or proposal based on current status; paragraph(s) and code.</p>
+        <p>The following is <a href="https://web.dev/constructable-stylesheets/#using-constructed-stylesheets" target="_blank">an example</a> of what this would look like in practice.</p>
+        <pre>
+          const sheet = new CSSStyleSheet();
+          sheet.replaceSync('a { color: red; }');
+          
+          // Apply the stylesheet to a document:
+          document.adoptedStyleSheets = [sheet];
+          
+          // Apply the stylesheet to a Shadow Root:
+          const node = document.createElement('div');
+          const shadow = node.attachShadow({ mode: 'open' });
+          shadow.adoptedStyleSheets = [sheet];
+        </pre>
       </section>
       <section>
         <h3>Key Scenarios</h3>
-        <p>---</p>
+        <ul>
+          <li>There is no effective way to share styles across components while allowing them to be centrally modified.</li>
+          <li>Creating `&lt;style&gt;` elements for each style used in each shadow root has a measurable performance overhead.</li>
+          <li>CSS Module Scripts, another critical feature, depends on constructible stylesheets.</li>
+        </ul>
       </section>
       <section>
         <h3>Concerns</h3>
-        <ul>
-          <li>---</li>
-        </ul>
+        <p>From their standards position tracker, Safari has highlighted some of the following concerns:</p>
+          <ul>
+            <li>Issues related to <a href="https://github.com/WICG/construct-stylesheets/issues/45" target="_blank">race conditions</a> with adopting stylesheets and if the adoptedStyleSheets array should be directly mutable or not</li>
+            <li>There is concern that it is <a href="https://github.com/whatwg/dom/pull/892#pullrequestreview-593774559" target="_blank">incompatible with Declarative Shadow DOM</a>.</li>
+            <li>Outstanding questions around <a href="https://github.com/WICG/webcomponents/issues/870" target="_blank"><em>@import</em> statements in CSS Modules</a>.</li>
+          </ul>
+        </p>
       </section>
       <section>
         <h3>Dissenting Opinion</h3>
-        <ul>
-          <li>---</li>
-        </ul>
+        <li>---</li>
       </section>
       <section>
         <h3>Related Specs</h3>
         <ul>
-          <li>---</li>
+          <li><a href="/#declarative-shadow-dom" target="_blank">Declarative Shadow DOM</a></li>
+          <li><a href="/#css-module-scripts" target="_blank">CSS Module Scripts</a></li>
         </ul>
       </section>
       <section>

--- a/reports/2022.html
+++ b/reports/2022.html
@@ -23,6 +23,10 @@
             name: "Alan Dávalos",
             url: "https://github.com/alangdm",
           },
+          {
+            name: "Caleb Williams",
+            url: "https://github.com/calebdwilliams"
+          }
         ],
         github: "w3c/webcomponents-cg",
         shortName: "webcomponents-cg",
@@ -199,51 +203,157 @@
           <dt>Previous WCCG Report(s)</dt>
           <dd><a href="https://w3c.github.io/webcomponents-cg/index.html#form-associated-custom-elements">2021</a></dd>
           <dt>GitHub issues:</dt>
-          <dd>---</dd>
+          <dd><a href="https://github.com/whatwg/html/issues">https://github.com/whatwg/html/issues</a></dd>
           <dt>Browser positions:</dt>
-          <dd>---</dd>
+          <dd>
+            <ul>
+              <li>
+                <a href="https://github.com/WebKit/standards-positions/issues/47">WebKit</a>
+              </li>
+            </ul>
+          </dd>
         </dl>
       </section>
       <section>
         <h3>Description</h3>
-        <p>---</p>
+        <p>The form-associated custom elements APIs enable custom elements to participate in form submission and validation lifecycles.</p>
       </section>
       <section>
         <h3>Status</h3>
         <ul>
-          <li>---</li>
+          <li>
+            <a href="https://chromestatus.com/feature/4708990554472448">Chrome/Edge (shipped in version 77)</a>
+          </li>
+          <li>
+            <a href="https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/setFormValue">Firefox (shipped in version 90)</a>
+          </li>
+          <li>
+            Safari has <a href="https://github.com/WebKit/WebKit/pull/2690">merged a PR implementing the first part of the ElementInternals spec</a> which includes the form-associated custom elements behavior; however, the initial PR doesn't include the actual form-association APIs. The polyfill does check for the presence of the form-associated APIs separately from ElementInternals, so this is not likely to cause any issues if it is released in part.
+          </li>
         </ul>
       </section>
       <section>
         <h3>Initial API Summary/Quick API Proposal</h3>
-        <p>Summary or proposal based on current status; paragraph(s) and code.</p>
+        <p>The form-associated custom elements APIs are implemented within the attachInternals method on the HTMLElement prototype. Calling attachInternals returns an instance of an ElementInternals object which grants developers the ability to interact with form elements provided they designate their element as a form-associated element.</p>
+        <pre>
+          <code>
+    %gt;form>
+      %gt;fancy-input name="fancy">%gt;/fancy-input>
+    %gt;/form>
+    
+    %gt;script>
+      class FancyInput extends HTMLElement {
+        static get formAssociated() {
+          return true;
+        }
+      
+        constructor() {
+          super();
+          this.#internals = this.attachInternals();
+          this.#internals.setFormValue('I can participate in a form!');
+        }
+      }
+    
+      customElements.define('fancy-input', FancyInput);
+      
+      document.querySelector('form').addEventListener('submit', event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        
+        console.log(formData.get('fancy')); // logs 'I can participate in a form!'
+      });
+    %gt;/script>
+          </code>
+        </pre>
+        <p>The <code>setFormValue</code> method can accept several types of data including strings, <code>FileData</code> and <code>FormData</code> objects, the latter of which can allow a nested form to participate with a parent in its entirety.</p>
+        <p>In addition to providing an method for adding a value to a form object, the form-associated APIs provide a surface to allow custom elements to participate in form validation.</p>
+        <pre>
+          <code>
+class FancyInput extends HTMLElement {
+  static get formAssociated() {
+    return true;
+  }
+
+  constructor() {
+    super();
+    const root = this.attachShadow({ mode: 'open' });
+    this.#internals = this.attachInternals();
+    this.#internals.setFormValue('I can participate in a form!');
+    const button = document.createElement('button');
+    root.append(button);
+    
+    button.addEventListener('click', this.#onClick);
+    this.button = button;
+  }
+  
+  #onClick = () => {
+    if (this.#internals.invalid) {
+      this.#internals.setValidity(); // Marks the element as valid
+    } else {
+      this.#internals.setValidity({
+        customError: true
+        }, 'You must click the button', this.button); // Marks the element as invalid and will focus on the button when the form checks validity
+  }
+}
+          </code>
+        </pre>
       </section>
       <section>
         <h3>Key Scenarios</h3>
-        <p>---</p>
+        <ul>
+          <li>Enable custom elements to participate in form submission by adding a value to the <code>FormData</code> object, adding to the <code>HTMLFormElement.prototype.elements</code> object and in other submission formats.</li>
+          <li>Enables custom elements to participate in the form validation lifecycle by providing APIs similar to and building on top of the constraint validation APIs.</li>
+        </ul>
       </section>
       <section>
         <h3>Concerns</h3>
         <ul>
-          <li>---</li>
+          <li><a href="https://github.com/whatwg/html/issues/5891">HTMLFormElement elements does not contain form-associated CustomElements when name attribute is shared</a></li>
+          <li>The form-associated APIs currently have <a href="https://github.com/WICG/webcomponents/issues/814">no way for a developer to behave as a custom submit button</a>. Though there are <a href="https://twitter.com/justinfagnani/status/1510387984830386180">several</a> <a href="https://github.com/open-wc/form-participation/tree/main/packages/form-helpers#implicit-form-submit">workarounds</a>.</li>
         </ul>
       </section>
       <section>
         <h3>Dissenting Opinion</h3>
-        <ul>
-          <li>---</li>
-        </ul>
       </section>
       <section>
         <h3>Related Specs</h3>
         <ul>
-          <li>---</li>
+          <li>
+            <code>CustomStateSet</code>
+            <ul>
+              <li>
+                <a href="https://wicg.github.io/custom-state-pseudo-class/#customstateset">Specification</a>
+              </li>
+              <li>
+                <a href="https://developer.mozilla.org/en-US/docs/Web/API/CustomStateSet">
+                  <abbr title="Mozilla Developer Network">MDN</abbr>
+                </a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <a href="https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object">
+              AriaMixin/accessibility object model
+            </a>
+          </li>
         </ul>
       </section>
       <section>
         <h3>Open Questions</h3>
         <ul>
-          <li>---</li>
+          <li>
+            It is currently unclear how form-associated custom elements should participate in the autocomplete lifecycle despite there being an API for that purpose. It is currently unclear per the spec how this behavior should work. Currently Chromium implements code for the <code>formStateRestoreCallback</code> callback only for restore events (such as back button or page refresh), but does not call the custom element reaction for autocomplete. Firefox currently does not ship any code referencing the <code>formStateRestoreCallback</code>.
+            <ul>
+              <li>
+                <a href="https://github.com/whatwg/html/issues/7292">Form restoration interop</a>
+              </li>
+              <li>
+                <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1335202">
+                  Chromimum Issue 1335202: formStateRestoreCallback custom element reaction will not be called for 'autocomplete'
+                </a>
+              </li>
+            </ul>
+          </li>
         </ul>
       </section>
     </section>

--- a/reports/2022.html
+++ b/reports/2022.html
@@ -544,19 +544,33 @@ class FancyInput extends HTMLElement {
           <dt>Previous WCCG Report(s)</dt>
           <dd><a href="https://w3c.github.io/webcomponents-cg/index.html#scoped-element-registries">2021</a></dd>
           <dt>GitHub issues:</dt>
-          <dd>---</dd>
+          <dd><a href="https://github.com/WICG/webcomponents/issues/716">WICG/webcomponents#716</a></dd>
           <dt>Browser positions:</dt>
-          <dd>---</dd>
+          <dd>
+            <ul>
+              <li>
+                <a href="https://github.com/WebKit/standards-positions/issues/38">WebKit</a>
+              </li>
+              <li>
+                <a href="https://groups.google.com/a/chromium.org/g/blink-dev/c/um-9YjJWyEQ/m/MhKN0L7FAgAJ">Chromium</a>
+              </li>
+              <li>
+                <a href="https://github.com/mozilla/standards-positions/issues/424">Mozilla</a>
+              </li>              
+            </ul>
+          </dd>
         </dl>
       </section>
       <section>
         <h3>Description</h3>
-        <p>---</p>
+        <p>Scoped element registries allow custom element definitions to be scoped to one or more shadow roots. This allows the same tag name to be used with different implementations in different parts of the page, greatly reducing tag name collisions.</p>
       </section>
       <section>
         <h3>Status</h3>
         <ul>
-          <li>---</li>
+          <li>Chromium: prototyping</li>
+          <li>WebKit: ?</li>
+          <li>Mozilla: ?</li>
         </ul>
       </section>
       <section>
@@ -565,18 +579,24 @@ class FancyInput extends HTMLElement {
       </section>
       <section>
         <h3>Key Scenarios</h3>
-        <p>---</p>
+        <ul>
+          <li>Building an app npm lbiraries that define elements. npm may duplicate packages and therefore custom element definitions.</li>
+          <li>Complex multi-team applications. Sub-teams often develop and deploy subsystems separately and may include multiple copies of libraries that define custom elements.</li>
+          <li>Complex elements with other custom elements as internal implementation detail. These elements may not want to take up names in the global registry for their sub-components.</li>
+          <li>Distributing elements via npm and CDNs. If both distribution methods are used on a page, one will error. npm usage can be directed to use scoped registries to avoid collisions.</li>
+          <li>Plug in systems. Plug-ins might bring their own custom element definitions which should not collide with the application or other plugins.</li>
+        </ul>
       </section>
       <section>
         <h3>Concerns</h3>
         <ul>
-          <li>---</li>
+          <li>Interaction with declarative shadow DOM (addressed)</li>
         </ul>
       </section>
       <section>
         <h3>Dissenting Opinion</h3>
         <ul>
-          <li>---</li>
+          <li>None</li>
         </ul>
       </section>
       <section>
@@ -588,7 +608,9 @@ class FancyInput extends HTMLElement {
       <section>
         <h3>Open Questions</h3>
         <ul>
-          <li>---</li>
+          <li><a href="https://github.com/WICG/webcomponents/issues/914">[scoped-registries] Interaction with declarative shadow DOM #914</a></li>
+          <li><a href="https://github.com/WICG/webcomponents/issues/907">Scoped Custom Element Registry: Moving elements with shadow roots between documents #907</a></li>
+          <li><a href="https://github.com/WICG/webcomponents/issues/923">[scoped-registries] Element upgrade ordering #923</a></li>
         </ul>
       </section>
     </section>

--- a/reports/2022.html
+++ b/reports/2022.html
@@ -24,6 +24,10 @@
             url: "https://github.com/alangdm",
           },
           {
+            name: "Owen Buckley",
+            url: "https://github.com/thescientist13",
+          },
+          {
             name: "Caleb Williams",
             url: "https://github.com/calebdwilliams"
           }
@@ -592,57 +596,71 @@ class FancyInput extends HTMLElement {
           <dt>Previous WCCG Report(s)</dt>
           <dd><a href="https://w3c.github.io/webcomponents-cg/index.html#declarative-shadow-dom">2021</a></dd>
           <dt>GitHub issues:</dt>
-          <dd>---</dd>
+          <dd><a href="https://github.com/whatwg/dom/issues/831">https://github.com/whatwg/dom/issues/831</a></dd>
           <dt>Browser positions:</dt>
-          <dd>---</dd>
+          <dd><a href="https://chromestatus.com/feature/5191745052606464">Chrome (Shipped)</a></dd>
+          <dd><a href="https://github.com/mozilla/standards-positions/issues/335">Mozilla</a></dd>
+          <dd><a href="https://github.com/WebKit/standards-positions/issues/12">Safari</a></dd>
         </dl>
       </section>
       <section>
         <h3>Description</h3>
-        <p>---</p>
+        <p>Declarative Shadow DOM is a mechanism to express Shadow DOM using only HTML, with no dependency on JavaScript, much like light DOM can be declaratively expressed today.</p>
       </section>
       <section>
         <h3>Links</h3>
         <ul>
-          <li>---</li>
+          <li><a href="https://web.dev/declarative-shadow-dom">Declarative Shadow DOM</a></li>
         </ul>
       </section>
       <section>
         <h3>Status</h3>
         <ul>
-          <li>---</li>
+          <li>Partial consensus, some implementation</li>
         </ul>
       </section>
       <section>
         <h3>Initial API Summary/Quick API Proposal</h3>
-        <p>Summary or proposal based on current status; paragraph(s) and code.</p>
+        <p>
+          <pre>
+            &lt;host-element&gt;
+              &lt;template shadowroot="open"&gt;
+                &lt;slot&gt;&lt;/slot&gt;
+              &lt;/template&gt;
+              &lt;h2>Light content&lt;/h2>&gt;
+            &lt;/host-element>
+          </pre>
+        </p>
       </section>
       <section>
         <h3>Key Scenarios</h3>
-        <p>---</p>
+        <p>Server-Side Rendering: Without Declarative Shadow DOM, servers cannot deliver complete websites that include web component content. Markup cannot be efficiently delivered and then hydrated with JavaScript client-side.</p>
+        <p>JavaScript-less environments: Many web components could be implemented without JavaScript, taking advantage of encapsulated DOM and styles. However, web components cannot currently be rendered by users who have JavaScript disabled. Developers who are more comfortable with markup than with scripting may avoid shadow DOM altogether due to its tight coupling with JavaScript..</p>
       </section>
       <section>
         <h3>Concerns</h3>
         <ul>
-          <li>---</li>
+          <li>Mozilla considers this to be non-harmful, though debates the merits on ROI to developers weighed against the added complexity to be added to the HTML parser from a performance perspective.</li>
+          <li>Safari would like to see compatibility with Scoped Element Registry addressed first.</li>
         </ul>
       </section>
       <section>
         <h3>Dissenting Opinion</h3>
         <ul>
-          <li>---</li>
+          <li>N / A</li>
         </ul>
       </section>
       <section>
         <h3>Related Specs</h3>
         <ul>
-          <li>---</li>
+          <li><a href="https://github.com/WICG/webcomponents/issues/716">Scoped Element Registries</a></li>
         </ul>
       </section>
       <section>
         <h3>Open Questions</h3>
         <ul>
-          <li>---</li>
+          <li>Mozilla would like to see more <a href="https://github.com/whatwg/dom/issues/831#issuecomment-988394185">real world uses cases</a> of Declarative Shadow DOM in the wild.  Which is a bit of a catch-22 when it is only supported in one browser and requires a polyfill.</li>
+          <li>Safari would like to <a href="https://github.com/whatwg/dom/issues/831#issuecomment-797845645">get consensus on the solution for Scoped Element Registries first.</a></li>
         </ul>
       </section>
     </section>

--- a/reports/2022.html
+++ b/reports/2022.html
@@ -228,7 +228,7 @@
             <a href="https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/setFormValue">Firefox (shipped in version 90)</a>
           </li>
           <li>
-            Safari has <a href="https://github.com/WebKit/WebKit/pull/2690">merged a PR implementing the first part of the ElementInternals spec</a> which includes the form-associated custom elements behavior; however, the initial PR doesn't include the actual form-association APIs. The polyfill does check for the presence of the form-associated APIs separately from ElementInternals, so this is not likely to cause any issues if it is released in part.
+            <a href="https://github.com/WebKit/standards-positions/issues/47#issuecomment-1221419927">WebKit is in favor and has the feature in active development</a> and has <a href="https://github.com/WebKit/WebKit/pull/2690">merged a PR implementing the first part of <code>ElementInternals</code></a> which includes the form-associated custom elements behavior; however, the initial PR doesn't include the actual form-association APIs.
           </li>
         </ul>
       </section>
@@ -311,9 +311,6 @@ class FancyInput extends HTMLElement {
           <li><a href="https://github.com/whatwg/html/issues/5891">HTMLFormElement elements does not contain form-associated CustomElements when name attribute is shared</a></li>
           <li>The form-associated APIs currently have <a href="https://github.com/WICG/webcomponents/issues/814">no way for a developer to behave as a custom submit button</a>. Though there are <a href="https://twitter.com/justinfagnani/status/1510387984830386180">several</a> <a href="https://github.com/open-wc/form-participation/tree/main/packages/form-helpers#implicit-form-submit">workarounds</a>.</li>
         </ul>
-      </section>
-      <section>
-        <h3>Dissenting Opinion</h3>
       </section>
       <section>
         <h3>Related Specs</h3>

--- a/reports/2022.html
+++ b/reports/2022.html
@@ -479,7 +479,9 @@ class FancyInput extends HTMLElement {
       </section>
       <section>
         <h3>Dissenting Opinion</h3>
-        <li>---</li>
+        <ul>
+          <li>---</li>
+        </ul>
       </section>
       <section>
         <h3>Related Specs</h3>

--- a/reports/2022.html
+++ b/reports/2022.html
@@ -370,51 +370,106 @@ class FancyInput extends HTMLElement {
           <dt>Previous WCCG Report(s)</dt>
           <dd><a href="https://w3c.github.io/webcomponents-cg/index.html#cross-root-aria">2021</a></dd>
           <dt>GitHub issues:</dt>
-          <dd>---</dd>
+          <dd><a href="https://github.com/leobalter/cross-root-aria-delegation" target="_blank">Cross-root ARIA Delegation</a></dd>
+          <dd><a href="https://github.com/Westbrook/cross-root-aria-reflection" target="_blank">Cross-root ARIA Reflection</a></dd>
           <dt>Browser positions:</dt>
           <dd>---</dd>
         </dl>
       </section>
       <section>
         <h3>Description</h3>
-        <p>---</p>
+        <p>
+          Shadow boundaries prevent content on either side of the boundary from referencing each other via ID references. ID references being the basis of the majority of the accessibility patters outlines by aria attributes, this causes a major issue in developing accessible content with shadow DOM. While there are ways to develop these UIs by orchestrating the relationships between elements of synthesizing the passing of content across a shadow boundary, these practices generally position accessible development out of reach for most developers, both at component creation and component consumption time.
+        </p>
+        <p>
+          Developers of a custom element should be able to outline to browsers how content from outside of their shadow root realtes to the content within it and visa versa. Cross-root ARIA Delegation would allow developers to define how content on the outside is mapped to the content within a shadow root, while Cross-root ARIA Reflection would define how content within a shadow root was made available to content outside of it.
+        </p>
       </section>
       <section>
         <h3>Status</h3>
-        <ul>
-          <li>---</li>
-        </ul>
+        <p>
+          Implementors participating in bi-weekly Accessibility Object Model syncs with WICG have all been favorable to the delegation work and are interested in the reflection work as a tighly related API that maybe is a fast follower. Leo Balter is working on finalizing proposal text for the delegation API at which time Westbrook Johnson will apply similar teminology to the reflection API proposal.
+        </p>
       </section>
       <section>
         <h3>Initial API Summary/Quick API Proposal</h3>
-        <p>Summary or proposal based on current status; paragraph(s) and code.</p>
+        <h4>Delegation API</h4>
+        <p>HTML</p>
+        <pre>
+          <code>
+            &lt;span id="foo">Description!&lt;/span>
+            &lt;template id="template1">
+              &lt;input id="input" autoarialabel autoariadescribedby />
+              &lt;span autoarialabel>Another target&lt;/span>
+            &lt;/template>
+            &lt;x-foo aria-label="Hello!" aria-describedby="foo">&lt;/x-foo>
+          </code>
+        </pre>
+        <p>JS</p>
+        <pre>
+          <code>
+            const template = document.getElementById('template1');
+
+            class XFoo extends HTMLElement {
+              constructor() {
+                super();
+                this.attachShadow({ mode: "open", delegatesAriaLabel: true, delegatesAriaDescribedBy: true });
+                this.shadowRoot.appendChild(template.content.cloneNode(true));
+              }
+            }
+
+            customElements.define("x-foo", XFoo);
+          </code>
+        </pre>
+        <h4>Reflection API</h4>
+        <p>HTML</p>
+        <pre>
+          <code>
+            &lt;input aria-controlls="foo" aria-activedescendent="foo">Description!&lt;/span>
+            &lt;template id="template1">
+              &lt;ul reflectariacontrols>
+                &lt;li>Item 1&lt;/li>
+                &lt;li reflectariaactivedescendent>Item 2&lt;/li>
+                &lt;li>Item 3&lt;/li>
+              </ul>
+            &lt;/template>
+            &lt;x-foo id="foo">&lt;/x-foo>
+          </code>
+        </pre>
+        <p>JS</p>
+        <pre>
+          <code>
+            const template = document.getElementById('template1');
+
+            class XFoo extends HTMLElement {
+              constructor() {
+                super();
+                this.attachShadow({ mode: "open", reflectsAriaControls: true, reflectsAriaActivedescendent: true });
+                this.shadowRoot.appendChild(template.content.cloneNode(true));
+              }
+            }
+            customElements.define("x-foo", XFoo);
+          </code>
+        </pre>
       </section>
       <section>
         <h3>Key Scenarios</h3>
-        <p>---</p>
-      </section>
-      <section>
-        <h3>Concerns</h3>
-        <ul>
-          <li>---</li>
-        </ul>
-      </section>
-      <section>
-        <h3>Dissenting Opinion</h3>
-        <ul>
-          <li>---</li>
-        </ul>
+        <p>When developing many of the patterns outlines in the <a href="https://www.w3.org/WAI/ARIA/apg/patterns/" target="_blank">ARIA Authoring Practices Guide</a> having this capability would allow for encapsulating responsibilities outlined by the `role` attribute in a shadow root.</p>
       </section>
       <section>
         <h3>Related Specs</h3>
         <ul>
-          <li>---</li>
+          <li><a href="https://github.com/WICG/aom" target="_blank">AOM</a></li>
+          <li><a href="https://wicg.github.io/aom/aria-reflection-explainer.html" target="_blank">ARIA Reflection</a></li>
+          <li><a href="https://github.com/WICG/aom/blob/gh-pages/element_reference_properties.md" target="_blank">Element reference DOM properties</a></li>
         </ul>
       </section>
       <section>
         <h3>Open Questions</h3>
         <ul>
-          <li>---</li>
+          <li>Should these two ideas can/should really ship separately? While the reflection API was ideated after the delegation API it may not be practical to separate them at the implementation/comsuption level.</li>
+          <li>Is `delegation` and `reflection` the right name for these APIs? Particularly, "reflection" is used in <a href="https://wicg.github.io/aom/aria-reflection-explainer.html" target="_blank">ARIA Reflection</a>.</li>
+          <li>There are non-ARIA attributes that would benefit from being supported by these APIs. Should they be drafted in a more general way?</li>
         </ul>
       </section>
     </section>

--- a/reports/2022.html
+++ b/reports/2022.html
@@ -435,7 +435,7 @@ class FancyInput extends HTMLElement {
       </section>
       <section>
         <h3>Description</h3>
-        <p><a href="https://wicg.github.io/construct-stylesheets/" target="_blank">Constructable Stylesheets</a> and adoptedStyleSheets enable adding styles directly to shadow roots without creating new DOM elements. Because a single stylesheet object can be adopted by multiple scopes, it also allows sharing of styles that can be centrally modified.</p>
+        <p><a href="https://wicg.github.io/construct-stylesheets/" target="_blank">Constructable Stylesheets</a> and adoptedStyleSheets enable adding styles directly to DOM trees, e.g. `document` and shadow roots, without creating new DOM elements. Because a single stylesheet object can be adopted by multiple scopes, it also allows sharing of styles that can be centrally modified.</p>
       </section>
       <section>
         <h3>Status</h3>


### PR DESCRIPTION
- feat: add form-associated custom elements content
- chore(face): clarify WebKit position and remove dissenting opinion section
- added declarative shadow DOM (#45)
- docs: add API report update for declarative elements, lazy elements, DOM parts, and custom attributes (#41)
- constructable stylesheets initial draft
- fix build for invalid HTML
- Update reports/2022.html
- Add scoped custom element registries (#51)
- Add Cross Root Aria status (#46)
- feat: add CustomStateSet
